### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/Turtoodle/a399baa3-28e4-467d-8d14-47acb6bd2b5e/77b84d5f-e3ec-4961-9d4d-f3437dc23902/_apis/work/boardbadge/a0b0d38e-6d12-46a1-99f1-c18179c07873)](https://dev.azure.com/Turtoodle/a399baa3-28e4-467d-8d14-47acb6bd2b5e/_boards/board/t/77b84d5f-e3ec-4961-9d4d-f3437dc23902/Microsoft.RequirementCategory)
 # Homebrewing beer calculator
 
 My first long term project on the path to learning programming in C#.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Turtoodle/a399baa3-28e4-467d-8d14-47acb6bd2b5e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.